### PR TITLE
update captcha response urls

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 <!--
@@ -16,6 +15,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -31,10 +31,11 @@ Do you have any ideas on how we could fix this? It is okay if you have no idea!
 If applicable, add screenshots, a video, or a gif to help explain your problem.
 
 **System (please complete the following information):**
- - OS: [e.g. Windows, macOS, Linux]
- - Node Version: [e.g. 12, 15, 16]
- - Playwright (or Puppeteer) Version: [e.g. 1.12.0, 10.0.0]
- - tiktok-captcha-solver Version: [e.g. 0.0.3]
+
+- OS: [e.g. Windows, macOS, Linux]
+- Node Version: [e.g. 12, 15, 16]
+- Playwright (or Puppeteer) Version: [e.g. 1.12.0, 10.0.0]
+- tiktok-captcha-solver Version: [e.g. 0.0.3]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,6 @@ about: Suggest an idea for this project
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiktok-captcha-solver",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Solves the TikTok captcha interactively using playwright or puppeteer.",
   "main": "index.js",
   "scripts": {

--- a/src/CaptchaSolver.js
+++ b/src/CaptchaSolver.js
@@ -267,21 +267,29 @@ class CaptchaSolver {
     document.querySelector(puzzlePiece).style.display = 'block'
   }
 
-  _responseHandler() {
-    let maxContentLength = -1
+  validCaptchaUrl(url) {
+    const matchesSecurityCaptchaUrl = url.includes('security-captcha')
 
     const captchaImageSubUrls = [
       'captcha-us.ibyteimg.com/',
       'captcha-va.ibyteimg.com/',
     ]
 
+    const matchesByteImgUrls =
+      captchaImageSubUrls.find((subUrl) => url.includes(subUrl)) &&
+      url.includes('-2.jpeg')
+
+    return matchesSecurityCaptchaUrl || matchesByteImgUrls
+  }
+
+  _responseHandler() {
+    let maxContentLength = -1
+
     return async (response) => {
       const responseUrl = response.url()
-      if (
-        !captchaImageSubUrls.find((x) => responseUrl.includes(x)) ||
-        !responseUrl.includes('-2.jpeg')
-      )
+      if (!this.validCaptchaUrl(responseUrl)) {
         return
+      }
 
       const contentLength = Number(response.headers()['content-length'])
 

--- a/src/CaptchaSolver.js
+++ b/src/CaptchaSolver.js
@@ -101,7 +101,7 @@ class CaptchaSolver {
       const sliderContainer = await this.page.$(
         this.selectors.puzzleImageWrapper
       )
-      const sliderImage = await sliderContainer.screenshot();
+      const sliderImage = await sliderContainer.screenshot()
       const currentImage = await this._resizeImage(sliderImage)
 
       const rembrandt = new Rembrandt({
@@ -251,9 +251,9 @@ class CaptchaSolver {
   }
 
   async _resizeImage(image) {
-    const readResult = await Jimp.read(image);
-    const resize = await readResult.resize(276, 172);
-    return resize.getBufferAsync(Jimp.MIME_JPEG);
+    const readResult = await Jimp.read(image)
+    const resize = await readResult.resize(276, 172)
+    return resize.getBufferAsync(Jimp.MIME_JPEG)
   }
 
   _syncOverlayPositionWithPuzzlePiece({ puzzlePiece, puzzlePieceOverlay }) {
@@ -270,20 +270,26 @@ class CaptchaSolver {
   _responseHandler() {
     let maxContentLength = -1
 
-    const captchaImageSubUrls = ['captcha-us.ibyteimg.com/', 'captcha-va.ibyteimg.com/']
+    const captchaImageSubUrls = [
+      'captcha-us.ibyteimg.com/',
+      'captcha-va.ibyteimg.com/',
+    ]
 
     return async (response) => {
-      const responseUrl = response.url();
-      if (!captchaImageSubUrls.find(x => responseUrl.includes(x)) || !responseUrl.includes('-2.jpeg')) return;
+      const responseUrl = response.url()
+      if (
+        !captchaImageSubUrls.find((x) => responseUrl.includes(x)) ||
+        !responseUrl.includes('-2.jpeg')
+      )
+        return
 
       const contentLength = Number(response.headers()['content-length'])
 
       if (contentLength > maxContentLength) {
         maxContentLength = contentLength
-        this.startImage = await this._resizeImage(await (this.isPlaywright
-          ? response.body()
-          : response.buffer())
-        );
+        this.startImage = await this._resizeImage(
+          await (this.isPlaywright ? response.body() : response.buffer())
+        )
       }
     }
   }


### PR DESCRIPTION
# PR #5 TikTok captcha image URLs are wrong / not working

When the response comes back from TikTok, the response URL doesn't always include `security-captcha`. Rembrandt then throws an error that `this.startImage` is undefined. I'm not sure if the response URL has actually changed, or if it's some kind of obfuscation tactic by TikTok, so I still included the original prefix (`captchaImageSubUrls`).

In the logs, I noticed that the captcha URL's are like this: 

`https://p16-captcha-us.ibyteimg.com/tos-maliva-i-71rtze2081-us/...~tplv-...-2.jpeg`


- OS: Linux
- Node Version: 16.10.0
- Playwright / Puppeteer Version: All
- tiktok-captcha-solver Version: ^0.0.4